### PR TITLE
Yanghoo fixed freq

### DIFF
--- a/common/scheduler/policies/dvfsFixedFreq.cc
+++ b/common/scheduler/policies/dvfsFixedFreq.cc
@@ -1,0 +1,49 @@
+#include "dvfsFixedFreq.h"
+#include <iomanip>
+#include <iostream>
+
+using namespace std;
+
+DVFSFixedFreq::DVFSFixedFreq(const PerformanceCounters *performanceCounters,
+                                     int coreRows,
+                                     int coreColumns,
+                                     int freqCore0,
+                                     int freqCore1,
+                                     int freqCore2,
+                                     int freqCore3)
+        : performanceCounters(performanceCounters),
+          coreRows(coreRows),
+          coreColumns(coreColumns),
+          freqCore0(freqCore0),
+          freqCore1(freqCore1),
+          freqCore2(freqCore2),
+          freqCore3(freqCore3) {
+
+    this->coresFreq.push_back(freqCore0);
+    this->coresFreq.push_back(freqCore1);
+    this->coresFreq.push_back(freqCore2);
+    this->coresFreq.push_back(freqCore3);
+}
+
+std::vector<int>
+DVFSFixedFreq::getFrequencies(const std::vector<int> &oldFrequencies, const std::vector<bool> &activeCores) {
+    std::vector<int> frequencies(coreRows *coreColumns);
+
+    for (unsigned int coreCounter = 0; coreCounter < coreRows * coreColumns; coreCounter++) {
+        if (activeCores.at(coreCounter)) {
+            float power = performanceCounters->getPowerOfCore(coreCounter);
+            float temperature = performanceCounters->getTemperatureOfCore(coreCounter);
+            int frequency = oldFrequencies.at(coreCounter);
+            float utilization = performanceCounters->getUtilizationOfCore(coreCounter);
+
+            cout << "[Scheduler][DVFS_ISOLATION_FREQ]: Core " << setw(2) << coreCounter << ":";
+            cout << " P=" << fixed << setprecision(3) << power << " W";
+            cout << " f=" << frequency << " MHz";
+            cout << " T=" << fixed << setprecision(1) << temperature << " °C";
+            cout << " utilization=" << fixed << setprecision(3) << utilization << endl;
+        }
+        frequencies.at(coreCounter) = this->coresFreq[coreCounter] * 1000;
+    }
+
+    return frequencies;
+}

--- a/common/scheduler/policies/dvfsFixedFreq.h
+++ b/common/scheduler/policies/dvfsFixedFreq.h
@@ -1,0 +1,35 @@
+/**
+ * This header implements the max. freq DVFS policy
+ */
+
+#ifndef __DVFS_ISOLATION_H
+#define __DVFS_ISOLATION_H
+
+#include <vector>
+#include "dvfspolicy.h"
+
+class DVFSFixedFreq : public DVFSPolicy {
+public:
+    DVFSFixedFreq(
+            const PerformanceCounters *performanceCounters,
+            int coreRows,
+            int coreColumns,
+            int freqCore0,
+            int freqCore1,
+            int freqCore2,
+            int freqCore3
+            );
+    virtual std::vector<int> getFrequencies(const std::vector<int> &oldFrequencies, const std::vector<bool> &activeCores);
+
+private:
+    const PerformanceCounters *performanceCounters;
+    unsigned int coreRows;
+    unsigned int coreColumns;
+    int freqCore0;
+    int freqCore1;
+    int freqCore2;
+    int freqCore3;
+    std::vector<int> coresFreq;
+};
+
+#endif

--- a/common/scheduler/policies/dvfsOndemand.cc
+++ b/common/scheduler/policies/dvfsOndemand.cc
@@ -1,0 +1,91 @@
+#include "dvfsOndemand.h"
+#include <iomanip>
+#include <iostream>
+
+using namespace std;
+
+DVFSOndemand::DVFSOndemand(const PerformanceCounters *performanceCounters,
+                           int coreRows,
+                           int coreColumns,
+                           int minFrequency,
+                           int maxFrequency,
+                           int frequencyStepSize,
+                           float upThreshold,
+                           float downThreshold,
+                           float dtmCriticalTemperature,
+                           float dtmRecoveredTemperature)
+: performanceCounters(performanceCounters),
+  coreRows(coreRows),
+  coreColumns(coreColumns),
+  minFrequency(minFrequency),
+  maxFrequency(maxFrequency),
+  frequencyStepSize(frequencyStepSize),
+  upThreshold(upThreshold),
+  downThreshold(downThreshold),
+  dtmCriticalTemperature(dtmCriticalTemperature),
+  dtmRecoveredTemperature(dtmRecoveredTemperature) {}
+
+std::vector<int> DVFSOndemand::getFrequencies(const std::vector<int> &oldFrequencies,
+                                               const std::vector<bool> &activeCores) {
+    if (throttle()) {
+        std::vector<int> minFrequencies(coreRows * coreColumns, minFrequency);
+        cout << "[Scheduler][ondemand-DTM]: in throttle mode -> return min frequencies" << endl;
+        return minFrequencies;
+    } else {
+        std::vector<int> frequencies(coreRows * coreColumns);
+        for (unsigned int coreCounter = 0; coreCounter < coreRows * coreColumns; coreCounter++) {
+            if (activeCores.at(coreCounter)) {
+                float power = performanceCounters->getPowerOfCore(coreCounter);
+                float temperature = performanceCounters->getTemperatureOfCore(coreCounter);
+                int frequency = oldFrequencies.at(coreCounter);
+                float utilization = performanceCounters->getUtilizationOfCore(coreCounter);
+                cout << "[Scheduler][ondemand]: Core " << setw(2) << coreCounter << ":";
+                cout << " P=" << fixed << setprecision(3) << power << " W";
+                cout << " f=" << frequency << " MHz";
+                cout << " T=" << fixed << setprecision(1) << temperature << " C";
+                cout << " utilization=" << fixed << setprecision(3) << utilization << endl;
+                
+                if (utilization > upThreshold) {
+                    cout << "[Scheduler][ondemand]: utilization > upThreshold";
+                    if (frequency == maxFrequency) {
+                        cout << " but already at max frequency" << endl;
+                    } else {
+                        cout << " -> go to max frequency" << endl;
+                        frequency = maxFrequency;
+                    }
+                } else if (utilization < downThreshold) {
+                    cout << "[Scheduler][ondemand]: utilization < downThreshold";
+                    if (frequency == minFrequency) {
+                        cout << " but already at min frequency" << endl;
+                    } else {
+                        cout << " -> lower frequency" << endl;
+                        frequency = frequency * 80 / 100;
+                        frequency = (frequency / frequencyStepSize) * frequencyStepSize; // round
+                        if (frequency < minFrequency) {
+                            frequency = minFrequency;
+                        }
+                    }
+                }
+                frequencies.at(coreCounter) = frequency;
+            } else {
+                frequencies.at(coreCounter) = minFrequency;
+            }
+        }
+        return frequencies;
+    }
+}
+
+bool DVFSOndemand::throttle() {
+    if (performanceCounters->getPeakTemperature() > dtmCriticalTemperature) {
+        if (!in_throttle_mode) {
+            cout << "[Scheduler][ondemand-DTM]: detected thermal violation" << endl;
+        }
+        in_throttle_mode = true;
+    } else if (performanceCounters->getPeakTemperature() < dtmRecoveredTemperature) {
+        if (in_throttle_mode) {
+            cout << "[Scheduler][ondemand-DTM]: thermal violation ended" << endl;
+        }
+        in_throttle_mode = false;
+    }
+    return in_throttle_mode;
+}

--- a/common/scheduler/policies/dvfsOndemand.h
+++ b/common/scheduler/policies/dvfsOndemand.h
@@ -1,0 +1,45 @@
+/**
+* This header implements the ondemand governor with DTM.
+* The ondemand governor implementation is based on
+* Pallipadi, Venkatesh, and Alexey Starikovskiy.
+* "The ondemand governor."
+* Proceedings of the Linux Symposium. Vol. 2. No. 00216. 2006.
+*/
+#ifndef __DVFS_ONDEMAND_H
+#define __DVFS_ONDEMAND_H
+#include <vector>
+#include "dvfspolicy.h"
+#include "performance_counters.h"
+
+class DVFSOndemand : public DVFSPolicy {
+public:
+    DVFSOndemand(
+            const PerformanceCounters *performanceCounters,
+            int coreRows,
+            int coreColumns,
+            int minFrequency,
+            int maxFrequency,
+            int frequencyStepSize,
+            float upThreshold,
+            float downThreshold,
+            float dtmCriticalTemperature,
+            float dtmRecoveredTemperature);
+    virtual std::vector<int> getFrequencies(
+            const std::vector<int> &oldFrequencies,
+            const std::vector<bool> &activeCores);
+private:
+    const PerformanceCounters *performanceCounters;
+    unsigned int coreRows;
+    unsigned int coreColumns;
+    int minFrequency;
+    int maxFrequency;
+    int frequencyStepSize;
+    float upThreshold;
+    float downThreshold;
+    float dtmCriticalTemperature;
+    float dtmRecoveredTemperature;
+    bool in_throttle_mode = false;
+    bool throttle();
+};
+
+#endif

--- a/config/base.cfg
+++ b/config/base.cfg
@@ -1,3 +1,4 @@
+
 # Configuration file for the Sniper simulator
 
 # This file is organized into sections defined in [] brackets as in [section].
@@ -352,20 +353,22 @@ epoch = 1000000
 
 [scheduler/open/dvfs]
 logic = off  # set the DVFS algorithm used. Possible algorithms: off (no DVFS), maxFreq, fixedPower, testStaticPower.
-logic = maxFreq  # cfg:maxFreq
+#logic = maxFreq  # cfg:maxFreq
 #logic = testStaticPower  # cfg:testStaticPower
 min_frequency = 1.0
 max_frequency = 4.0
 #max_frequency = 1.0  # cfg:1.0GHz
-max_frequency = 2.0  # cfg:2.0GHz
+#max_frequency = 2.0  # cfg:2.0GHz
 #max_frequency = 3.0  # cfg:3.0GHz
-#max_frequency = 4.0  # cfg:4.0GHz
+max_frequency = 4.0  # cfg:4.0GHz
 frequency_step_size = 0.1
 dvfs_epoch = 1000000
 dvfs_epoch = 1000000 # cfg:slowDVFS
 #dvfs_epoch = 250000  # cfg:mediumDVFS
 #dvfs_epoch = 100000  # cfg:fastDVFS
 reserved_cores_are_active = false
+#logic = ondemand # cfg:ondemand
+logic = fixedFreq # cfg:fixedFreq
 
 [scheduler/open/dvfs/fixed_power]
 per_core_power_budget = 1  # in Watt
@@ -424,3 +427,15 @@ enabled = false
 reliability_executable = reliability/reliability_external
 sum_file = sums.txt
 acceleration_factor = 21600000000  # accel. delta_t from 1 ms -> 250 days
+
+[scheduler/open/dvfs/ondemand]
+up_threshold = 0.3
+down_threshold = 0.2
+dtm_cricital_temperature = 80
+dtm_recovered_temperature = 75
+
+[scheduler/open/dvfs/fixedFreq]
+freqCore0 = 4 #in GHz
+freqCore1 = 4 #in GHz
+freqCore2 = 4 #in GHz
+freqCore3 = 3 #in GHz

--- a/simulationcontrol/run.py
+++ b/simulationcontrol/run.py
@@ -262,7 +262,7 @@ def example():
 
         min_parallelism = get_feasible_parallelisms(benchmark)[0]
         max_parallelism = get_feasible_parallelisms(benchmark)[-1]
-        for freq in (1, 2):
+        for freq in (2, 4):
             #for parallelism in (max_parallelism,):
             for parallelism in (3, ):
                 # you can also use try_run instead
@@ -298,11 +298,27 @@ def multi_program():
 def test_static_power():
     run(['4.0GHz', 'testStaticPower', 'slowDVFS'], get_instance('parsec-blackscholes', 3, input_set='simsmall'))
 
+def test_parsec_multithreading():
+    for benchmark in (
+        'parsec-canneal',
+    ):
+        for freq in (4, ):
+            run(['{:.1f}GHz'.format(freq), 'maxFreq', 'slowDVFS'], get_instance(benchmark, 2, input_set='simsmall'))
+
+def test_parsec_dvfs_asymmetric():
+    run(['4.0GHz', 'fixedFreq', 'slowDVFS'], get_instance('parsec-blackscholes', 3, input_set='simsmall'))
+
+def test_parsec_dvfs():
+    return
+
+def thread_migration():
+    return
+
+def multi_program():
+    return
 
 def main():
-    example()
-    #test_static_power()
-    # multi_program()
+    test_parsec_dvfs_asymmetric()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The default base configuration file sets the core frequencies to 4GHz, 4GHz, 4GHz, and 3GHz respectively. This setup may be utilized to conduct experiments involving asymmetric DVFS policies. I recommend using four threads for optimal performance.
For details on executing this experiment, please look at the run() function within the run.py file.